### PR TITLE
feat: Support description specification

### DIFF
--- a/src/gh-repo-files-to-html.ts
+++ b/src/gh-repo-files-to-html.ts
@@ -54,11 +54,18 @@ export namespace GhRepoFilesToHtml {
         children.push(h('p', 'binary'))
       }
     }
+    const description = (() => {
+      if (client.description) {
+        return [h('p', client.description)]
+      }
+      return []
+    })()
     return hastToHtml(
       sanitize(
         h('div', [
           h('h1', client.title),
           h('p', client.info),
+          ...description,
           h('h2', 'files'),
           ...children
         ]),

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -35,6 +35,7 @@ export type FileKind = 'source' | 'image' | 'binary'
 
 export abstract class Client {
   protected _opts: ClientNomalizedOpts
+  protected _description: string | undefined = ''
   constructor(opts: ClientOpts) {
     this._opts = normalizeClientOpts(opts)
   }
@@ -47,6 +48,12 @@ export abstract class Client {
   }
   get title(): string {
     return `${this._opts.owner}/${this._opts.repo}/${this._opts.ref}`
+  }
+  set description(_description: string | undefined) {
+    this._description = _description
+  }
+  get description(): string | undefined {
+    return this._description
   }
   protected async fileKind(zipObj: JSZip.JSZipObject): Promise<FileKind> {
     const filepath = zipObj.name

--- a/test/gh-repo-files-to-html.spec.ts
+++ b/test/gh-repo-files-to-html.spec.ts
@@ -75,4 +75,15 @@ describe('GhRepoFilesToHtml.toHtml()', () => {
 </code></pre><h3>test.bin</h3><p>binary</p></div>"
 `)
   })
+  it('should return html(description)', async () => {
+    const client = new SimpleClient({
+      owner: 'hankei6km',
+      repo: 'gas-gh-repo-files-to-html'
+    })
+    client.description = 'test'
+    expect(await GhRepoFilesToHtml.filesToHtml(client)).toMatchInlineSnapshot(`
+"<div><h1>hankei6km/gas-gh-repo-files-to-html/main</h1><p>owner: hankei6km, repo: gas-gh-repo-files-to-html, ref: main, host: github.com, rawContentHost: raw.githubusercontent.com</p><p>test</p><h2>files</h2><h3>images/hiragana.png</h3><img src="https://raw.githubusercontent.com/hankei6km/gas-gh-repo-files-to-html/main/images/hiragana.png"><h3>README.txt</h3><pre><code>テストに使う zip に追加されるディレクトリ
+</code></pre><h3>test.bin</h3><p>binary</p></div>"
+`)
+  })
 })

--- a/test/lib/client.spec.ts
+++ b/test/lib/client.spec.ts
@@ -55,6 +55,15 @@ describe('Client', () => {
     })
     expect(client.title).toBe('hankei6km/gas-gh-repo-files-to-html/main')
   })
+  it('desciption', () => {
+    const client = new SimpleClient({
+      owner: 'hankei6km',
+      repo: 'gas-gh-repo-files-to-html'
+    })
+    expect(client.description).toBe('')
+    client.description = 'test'
+    expect(client.description).toBe('test')
+  })
   it('fileKind(image)', async () => {
     const client = new SimpleClient({
       owner: 'hankei6km',


### PR DESCRIPTION
This feature does not retrieve the description set on the GitHub repository.

Just allow specifying the description manually when generating HTML.
