### PR TITLE
docs: Add JSDoc comments to the "GhRepoFiles" namespace

### DIFF
--- a/src/gh-repo-files.ts
+++ b/src/gh-repo-files.ts
@@ -19,8 +19,24 @@ export function isErrRes(
   return false
 }
 
+/**
+ * GitHub リポジトリのファイルを操作するためのユーティリティを提供します。
+ */
 export namespace GhRepoFiles {
+  /**
+   * Google Apps Script 環境用の GitHub リポジトリクライアント。
+   *
+   * @remarks
+   * このクラスは、`Client` クラスを拡張し、Google Apps Script の `UrlFetchApp` を使用して
+   * GitHub リポジトリからファイルをフェッチします。
+   */
   export class GasClient extends Client {
+    /**
+     * GitHub リポジトリからファイルを ZIP アーカイブとしてフェッチします。
+     *
+     * @returns {Promise<Uint8Array>} ファイルの内容を含む `Uint8Array` を解決する Promise。
+     *          リクエストが失敗した場合、Promise は拒否されます。
+     */
     protected async fetch(): Promise<Uint8Array> {
       const url = new Url('')
         .set('protocol', 'https')
@@ -75,9 +91,23 @@ export namespace GhRepoFiles {
       defaultSchema
     )
   }
+
+  /**
+   * GitHub リポジトリのファイルリストを HTML 形式の文字列に変換します。
+   *
+   * @param {Client} client - GitHub リポジトリクライアント。
+   * @returns HTML 形式のファイルリストを表す文字列を解決する Promise。
+   */
   export async function filesToHtml(client: Client): Promise<string> {
     return hastToHtml(await filesToHHast(client))
   }
+
+  /**
+   * GitHub リポジトリのファイルリストを Markdown 形式の文字列に変換します。
+   *
+   * @param {Client} client - GitHub リポジトリクライアント。
+   * @returns Markdown 形式のファイルリストを表す文字列を解決する Promise。
+   */
   export async function filesToMarkdown(client: Client): Promise<string> {
     return mdastToMarkdown(hastToMdast(await filesToHHast(client)), {
       extensions: [gfmToMarkdown()]

--- a/src/index.js
+++ b/src/index.js
@@ -16,14 +16,32 @@ function setImmediate(callback, ...args) {
   return {}
 }
 
+/**
+ * GasClient クラスのコンストラクタ関数を返します。
+ *
+ * @returns {function(new: GasClient)} GasClient クラスのコンストラクタ関数。
+ */
 function getGasClient() {
   return _entry_point_.GhRepoFiles.GasClient
 }
 // class GasClient extends _entry_point_.GhRepoFiles.GasClient {} // これは GAS でロードときに _entry_point_ がないのでエスポートされない。たぶん。
 
+/**
+ * 指定されたクライアントとオプションを使用して、ファイルリストを HTML 形式に変換します。
+ *
+ * @param {Client} client - ファイルリストを取得するGitHubリポジトリクライアント。
+ * @returns {Promise<string>} HTML 形式のファイルリストを表す文字列を解決する Promise。
+ */
 function filesToHtml(client, opts) {
   return _entry_point_.GhRepoFiles.filesToHtml(client, opts)
 }
+
+/**
+ * 指定されたクライアントとオプションを使用して、ファイルリストを Markdown 形式に変換します。
+ *
+ * @param {Client} client - ファイルリストを取得するGitHubリポジトリクライアント。
+ * @returns {Promise<string>} Markdown 形式のファイルリストを表す文字列を解決する Promise。
+ */
 function filesToMarkdown(client, opts) {
   return _entry_point_.GhRepoFiles.filesToMarkdown(client, opts)
 }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -4,19 +4,52 @@ import chardet from 'chardet'
 import Url from 'url-parse'
 // import { fileTypeFromBuffer } from 'file-type' // TextEncoder が必要
 
+/**
+ * クライアントオプション。
+ */
 export type ClientOpts = {
+  /**
+   * リポジトリのオーナー名。
+   */
   owner: string
+  /**
+   * リポジトリ名。
+   */
   repo: string
+  /**
+   * ブランチ名、タグ名、またはコミットハッシュ。デフォルトは'main'。
+   */
   ref?: string
+  /**
+   * GitHubのホスト名。デフォルトは'github.com'。
+   */
   host?: string
+  /**
+   * rawコンテンツのホスト名。デフォルトは'raw.githubusercontent.com'。
+   */
   rawContentHost?: string
 }
 export type ClientNomalizedOpts = Required<ClientOpts>
 
+/**
+ * ファイルに関する情報を表すオブジェクト。
+ */
 export type FileInfo = {
+  /**
+   * ファイルの名前
+   */
   name: string
+  /**
+   * ファイルの種類
+   */
   kind: FileKind
+  /**
+   * ファイルの内容 (kindが'source'の場合のみ設定される)
+   */
   content: string
+  /**
+   * ファイルのrawコンテンツを取得するためのURL
+   */
   rawUrl: string
 }
 export type FileList = FileInfo[]
@@ -31,30 +64,91 @@ function normalizeClientOpts(opts: ClientOpts): ClientNomalizedOpts {
   }
 }
 
+/**
+ * ファイルの種類を表します。
+ * - `source`: TypeScriptやJavaScriptのソースコードファイルです。
+ * - `image`: PNGやJPEGなどの画像ファイルです。
+ * - `binary`: 上記以外のバイナリファイルです。
+ */
 export type FileKind = 'source' | 'image' | 'binary'
 
+/**
+ * GitHub リポジトリと対話するためのクライアント。
+ *
+ * @remarks
+ * このクラスは、GitHub リポジトリに関する情報へのアクセスと操作を提供するメソッドを定義しています。
+ * 具体的なファイル取得方法は、サブクラスで実装される `fetch` メソッドによって決定されます。
+ */
 export abstract class Client {
   protected _opts: ClientNomalizedOpts
   protected _description: string | undefined = ''
   constructor(opts: ClientOpts) {
     this._opts = normalizeClientOpts(opts)
   }
+
+  /**
+   * GitHub リポジトリからファイルをフェッチします。
+   *
+   * @remarks
+   * このメソッドは抽象メソッドであり、サブクラスで実装する必要があります。
+   *
+   * @returns {Promise<Uint8Array>} - ファイルの内容を含むPromise。
+   */
   protected abstract fetch(opts: ClientOpts): Promise<Uint8Array>
+
+  /**
+   * クライアントが保持する GitHub リポジトリに関する情報を返します。
+   *
+   * @returns {string} - オーナー、リポジトリ、ブランチ、ホスト、rawContentHost などのリポジトリ情報を含む文字列。
+   */
   get info(): string {
     return `owner: ${this._opts.owner}, repo: ${this._opts.repo}, ref: ${this._opts.ref}, host: ${this._opts.host}, rawContentHost: ${this._opts.rawContentHost}`
   }
+
+  /**
+   * "オーナー名 リポジトリ名 ブランチ名" 形式のドキュメント名を返します。
+   *
+   * @returns {string} - ドキュメント名を表す文字列。
+   */
   get documentName(): string {
     return `${this._opts.owner} ${this._opts.repo} ${this._opts.ref}`
   }
+
+  /**
+   * "オーナー名/リポジトリ名/ブランチ名" 形式のタイトルを返します。
+   *
+   * @returns {string} - タイトルを表す文字列。
+   */
   get title(): string {
     return `${this._opts.owner}/${this._opts.repo}/${this._opts.ref}`
   }
-  set description(_description: string | undefined) {
-    this._description = _description
+
+  /**
+   * リポジトリの説明文を設定します。
+   *
+   * @param {string | undefined} description - 新しい説明文。
+   */
+  set description(description: string | undefined) {
+    this._description = description
   }
+
+  /**
+   * リポジトリの説明文を返します。
+   *
+   * @remarks 実際の GitHub リポジトリの説明文ではなく、このクライアントで設定された説明文を返します。
+   *
+   * @returns {string | undefined} - リポジトリの説明文。設定されていない場合は `undefined`。
+   */
   get description(): string | undefined {
     return this._description
   }
+
+  /**
+   * ファイルの種類を判定します。
+   *
+   * @param {JSZip.JSZipObject} zipObj - JSZip オブジェクト。
+   * @returns {Promise<FileKind>} - ファイルの種類を表す `FileKind` 列挙型の値を含むPromise。
+   */
   protected async fileKind(zipObj: JSZip.JSZipObject): Promise<FileKind> {
     const filepath = zipObj.name
 
@@ -69,6 +163,13 @@ export abstract class Client {
 
     return 'binary'
   }
+
+  /**
+   * ファイルの raw コンテンツを取得するための URL を生成します。
+   *
+   * @param {string} filepath - ファイルのパス。
+   * @returns {string} - ファイルの raw コンテンツを取得するための URL。
+   */
   protected rawUrl(filepath: string): string {
     const url = new Url('')
       .set('protocol', 'https')
@@ -79,6 +180,12 @@ export abstract class Client {
       )
     return url.toString()
   }
+
+  /**
+   * GitHub リポジトリからファイルリストを取得します。
+   *
+   * @returns {Promise<FileList>} - ファイル情報を含む `FileInfo` オブジェクトの配列を含むPromise。
+   */
   async getFileList(): Promise<FileList> {
     const ret: FileList = []
     const data = await this.fetch(this._opts)


### PR DESCRIPTION
This commit adds JSDoc comments to the `GhRepoFiles` namespace and its
methods. The `GhRepoFiles` namespace provides utilities for manipulating
files in a GitHub repository.
