### PR TITLE
fix: Add getGasClient function to GhRepoFiles namespace

### DIFF
--- a/src/gh-repo-files.ts
+++ b/src/gh-repo-files.ts
@@ -61,6 +61,14 @@ export namespace GhRepoFiles {
       return new Uint8Array(res.getBlob().getBytes())
     }
   }
+  /**
+   * G asClient クラスのコンストラクタ関数を返します。
+   *
+   * @returns {function(new: GasClient)} GasClient クラスのコンストラクタ関数。
+   */
+  export function getGasClient(): typeof GasClient {
+    return GasClient
+  }
   async function filesToHHast(
     client: GhRepoFilesClient.Client
   ): Promise<Nodes> {

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ function setImmediate(callback, ...args) {
  * @returns {function(new: GasClient)} GasClient クラスのコンストラクタ関数。
  */
 function getGasClient() {
-  return _entry_point_.GhRepoFiles.GasClient
+  return _entry_point_.GhRepoFiles.getGasClient()
 }
 // class GasClient extends _entry_point_.GhRepoFiles.GasClient {} // これは GAS でロードときに _entry_point_ がないのでエスポートされない。たぶん。
 

--- a/test/gh-repo-files.spec.ts
+++ b/test/gh-repo-files.spec.ts
@@ -4,7 +4,7 @@ import { GhRepoFilesClient } from '../src/lib/client.js'
 //import type { ClientOpts, FileList } from '../src/lib/client.js'
 import { GhRepoFiles } from '../src/gh-repo-files.js'
 
-describe('GhRepoFiles.GasClient', () => {
+describe('GhRepoFiles.getGasClient', () => {
   const saveUrlFetchApp = global.UrlFetchApp
   afterEach(() => {
     global.UrlFetchApp = saveUrlFetchApp
@@ -21,7 +21,7 @@ describe('GhRepoFiles.GasClient', () => {
     global.UrlFetchApp = {
       fetch: mockfetch
     } as any
-    const client = new GhRepoFiles.GasClient({
+    const client = new (GhRepoFiles.getGasClient())({
       owner: 'hankei6km',
       repo: 'gas-gh-repo-files'
     })
@@ -43,7 +43,7 @@ describe('GhRepoFiles.GasClient', () => {
     global.UrlFetchApp = {
       fetch: mockfetch
     } as any
-    const client = new GhRepoFiles.GasClient({
+    const client = new (GhRepoFiles.getGasClient())({
       owner: 'hankei6km',
       repo: 'gas-gh-repo-files'
     })


### PR DESCRIPTION
TypeScript で型定義を使って記述したときと、 スクリプトエディターで
ライブラリーを追加して記述したときに利用する関数をあわせるため。
