### PR TITLE
fix!: Replace slash in document name with space

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -96,6 +96,7 @@ export namespace GhRepoFilesClient {
   export abstract class Client {
     protected _opts: ClientNomalizedOpts
     protected _description: string | undefined = ''
+    protected _slashReplacementCharinDocumentName: string = ' '
     constructor(opts: ClientOpts) {
       this._opts = normalizeClientOpts(opts)
     }
@@ -125,7 +126,11 @@ export namespace GhRepoFilesClient {
      * @returns {string} - ドキュメント名を表す文字列。
      */
     get documentName(): string {
-      return `${this._opts.owner} ${this._opts.repo} ${this._opts.ref}`
+      // new RegExp しておく？(とくに効率が必要な処理でもないか？)
+      return `${this._opts.owner} ${this._opts.repo} ${this._opts.ref.replace(
+        /\//g,
+        this._slashReplacementCharinDocumentName
+      )}`
     }
 
     /**

--- a/test/lib/client.spec.ts
+++ b/test/lib/client.spec.ts
@@ -72,6 +72,14 @@ describe('Client', () => {
     })
     expect(client.documentName).toBe('hankei6km gas-gh-repo-files main')
   })
+  it('documentName(slash)', () => {
+    const client = new SimpleClient({
+      owner: 'hankei6km',
+      repo: 'gas-gh-repo-files',
+      ref: 'topic/slash'
+    })
+    expect(client.documentName).toBe('hankei6km gas-gh-repo-files topic slash')
+  })
   it('title', () => {
     const client = new SimpleClient({
       owner: 'hankei6km',


### PR DESCRIPTION
GitHub のウェブ UI だと GitRef のスラッシュがそのまま URL に現れる。
(Android 版で `%2f` にエンコードされる)

Google ドライブ上でファイル名に `/` は許容されているようだが、
微妙に扱いにくいので置き換える。
