### PR TITLE
feat!: Remove div element from the root of the HTML

### DIFF
--- a/src/gh-repo-files.ts
+++ b/src/gh-repo-files.ts
@@ -95,7 +95,7 @@ export namespace GhRepoFiles {
       return []
     })()
     return sanitize(
-      h('div', [
+      h(null, [
         h('h1', client.title),
         h('p', client.info),
         ...description,

--- a/test/build/gh-repo-files_src.js
+++ b/test/build/gh-repo-files_src.js
@@ -22,7 +22,7 @@ describe('exported', () => {
     })
     // expect(await toHtml(client)).toMatchInlineSnapshot() // 連結したファイルでテストするので、ここには書き戻されない。
     expect(await filesToHtml(client)).toEqual(
-      '<div><h1>hankei6km/gas-gh-repo-files/main</h1><p>owner: hankei6km, repo: gas-gh-repo-files, ref: main, host: github.com, rawContentHost: raw.githubusercontent.com</p><h2>files</h2><h3>images/hiragana.png</h3><img src="https://raw.githubusercontent.com/hankei6km/gas-gh-repo-files/main/images/hiragana.png"></div>'
+      '<h1>hankei6km/gas-gh-repo-files/main</h1><p>owner: hankei6km, repo: gas-gh-repo-files, ref: main, host: github.com, rawContentHost: raw.githubusercontent.com</p><h2>files</h2><h3>images/hiragana.png</h3><img src="https://raw.githubusercontent.com/hankei6km/gas-gh-repo-files/main/images/hiragana.png">'
     )
   })
   it('should return markdown', async () => {

--- a/test/gh-repo-files.spec.ts
+++ b/test/gh-repo-files.spec.ts
@@ -71,12 +71,12 @@ describe('GhRepoFiles.toHtml()', () => {
       repo: 'gas-gh-repo-files'
     })
     expect(await GhRepoFiles.filesToHtml(client)).toMatchInlineSnapshot(`
-"<div><h1>hankei6km/gas-gh-repo-files/main</h1><p>owner: hankei6km, repo: gas-gh-repo-files, ref: main, host: github.com, rawContentHost: raw.githubusercontent.com</p><h2>files</h2><h3>images/hiragana.png</h3><img src="https://raw.githubusercontent.com/hankei6km/gas-gh-repo-files/main/images/hiragana.png"><h3>README.txt</h3><pre><code>テストに使う zip に追加されるディレクトリ
+"<h1>hankei6km/gas-gh-repo-files/main</h1><p>owner: hankei6km, repo: gas-gh-repo-files, ref: main, host: github.com, rawContentHost: raw.githubusercontent.com</p><h2>files</h2><h3>images/hiragana.png</h3><img src="https://raw.githubusercontent.com/hankei6km/gas-gh-repo-files/main/images/hiragana.png"><h3>README.txt</h3><pre><code>テストに使う zip に追加されるディレクトリ
 
 \`\`\`html
 &#x3C;p>テスト&#x3C;/p>
 \`\`\`
-</code></pre><h3>test.bin</h3><p>binary</p></div>"
+</code></pre><h3>test.bin</h3><p>binary</p>"
 `)
   })
   it('should return html(description)', async () => {
@@ -86,12 +86,12 @@ describe('GhRepoFiles.toHtml()', () => {
     })
     client.description = 'test'
     expect(await GhRepoFiles.filesToHtml(client)).toMatchInlineSnapshot(`
-"<div><h1>hankei6km/gas-gh-repo-files/main</h1><p>owner: hankei6km, repo: gas-gh-repo-files, ref: main, host: github.com, rawContentHost: raw.githubusercontent.com</p><p>test</p><h2>files</h2><h3>images/hiragana.png</h3><img src="https://raw.githubusercontent.com/hankei6km/gas-gh-repo-files/main/images/hiragana.png"><h3>README.txt</h3><pre><code>テストに使う zip に追加されるディレクトリ
+"<h1>hankei6km/gas-gh-repo-files/main</h1><p>owner: hankei6km, repo: gas-gh-repo-files, ref: main, host: github.com, rawContentHost: raw.githubusercontent.com</p><p>test</p><h2>files</h2><h3>images/hiragana.png</h3><img src="https://raw.githubusercontent.com/hankei6km/gas-gh-repo-files/main/images/hiragana.png"><h3>README.txt</h3><pre><code>テストに使う zip に追加されるディレクトリ
 
 \`\`\`html
 &#x3C;p>テスト&#x3C;/p>
 \`\`\`
-</code></pre><h3>test.bin</h3><p>binary</p></div>"
+</code></pre><h3>test.bin</h3><p>binary</p>"
 `)
   })
 })


### PR DESCRIPTION
ライブラリーを利用している側で要素を追加した場合、div があると
やりにくいので削除する。
