### PR TITLE
fix: Remove export from hastToHtml in src/index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ async function filesToHast(client) {
  * @param {Awaited<ReturnType<typeof filesToHast>>} hast - hast 形式のオブジェクト。
  * @returns HTML 形式の文字列
  */
-export function hastToHtml(hast) {
+function hastToHtml(hast) {
   return _entry_point_.GhRepoFiles.hastToHtml(hast)
 }
 /**


### PR DESCRIPTION
前回のリリースで、GAS のソースが更新されていなかった。

原因の切り分けとして、不必要な export を削除する。
